### PR TITLE
Allow showing historical results

### DIFF
--- a/search-api/bootstrap.py
+++ b/search-api/bootstrap.py
@@ -22,7 +22,6 @@ from search_api.models.corp_party import CorpParty
 from search_api.models.corp_name import CorpName
 from search_api.models.address import Address
 from search_api.models.office import Office
-#from search_api.models.office_type import OfficeType
 from search_api.models.party_type import PartyType
 from search_api.models.officer_type import OfficerType
 from search_api.models.offices_held import OfficesHeld
@@ -42,7 +41,6 @@ def reset():
     db.session.query(CorpOpState).delete(synchronize_session=False)
     db.session.query(CorpState).delete(synchronize_session=False)
     db.session.query(Address).delete(synchronize_session=False)
-    #db.session.query(OfficeType).delete(synchronize_session=False)
     db.session.query(Office).delete(synchronize_session=False)
     db.session.query(OfficerType).delete(synchronize_session=False)
     db.session.query(OfficesHeld).delete(synchronize_session=False)

--- a/search-api/search_api/models/corp_party.py
+++ b/search-api/search_api/models/corp_party.py
@@ -286,7 +286,9 @@ class CorpParty(BaseModel):
                 CorpName.corp_nme,
             )
         ).filter(
-            CorpParty.end_event_id == None,  # noqa # pylint: disable=singleton-comparison
+            # This can be used to find only the active corp parties, but we use CorpStatestateTypCd instead,
+            # So it's not needed:
+            # CorpParty.end_event_id == None,  # noqa # pylint: disable=singleton-comparison
             CorpParty.party_typ_cd != 'OFF',
         )
 

--- a/search-api/search_api/resources/businesses.py
+++ b/search-api/search_api/resources/businesses.py
@@ -66,14 +66,14 @@ def corporation_search():
     per_page = 50
     page = int(args.get('page')) if 'page' in args else 1
     # We've switched to using ROWNUM rather than pagination, for performance reasons.
-    # This means queries with more than 500 results are invalid.
+    # This means queries with more than 165 results are invalid.
     # results = results.limit(50).offset((page - 1) * 50).all()
     if current_app.config.get('IS_ORACLE'):
         results = results.filter(
-            literal_column('rownum') <= 500
-        ).yield_per(50)
+            literal_column('rownum') <= 165
+        )
     else:
-        results = results.limit(500)
+        results = results.limit(165)
 
     result_fields = [
         'corpNum',
@@ -121,10 +121,10 @@ def corporation_search_export():
     results = Corporation.search_corporations(args, include_addr=False)
     if current_app.config.get('IS_ORACLE'):
         results = results.filter(
-            literal_column('rownum') <= 500
-        ).yield_per(50)
+            literal_column('rownum') <= 165
+        )
     else:
-        results = results.limit(500)
+        results = results.limit(165)
 
     # Exporting to Excel
     workbook = Workbook()

--- a/search-api/search_api/resources/directors.py
+++ b/search-api/search_api/resources/directors.py
@@ -61,7 +61,6 @@ def corpparty_search():
     - sort_value={field name to sort results by}
     """
     current_app.logger.info('Starting director search')
-
     account_id = request.headers.get('X-Account-Id', None)
     if not authorized(jwt, account_id):
         return (
@@ -91,14 +90,17 @@ def corpparty_search():
     # update:
     # We've switched to using ROWNUM rather than pagination, for performance reasons.
     # for benchmarking, dump the query here and copy to benchmark.py
-    # This means queries with more than 500 results are invalid.
-    # from sqlalchemy.dialects import oracle
-    # results = results.limit(per_page).offset((page - 1) * per_page).all()
-    # oracle_dialect = oracle.dialect(max_identifier_length=30)
-    if current_app.config.get('IS_ORACLE'):  # raise Exception(results.statement.compile(dialect=oracle_dialect))
-        results = results.filter(literal_column('rownum') <= 500).yield_per(per_page)
+    # This means queries with more than 165 results are invalid.
+
+    if current_app.config.get('IS_ORACLE'):
+        results = results.filter(literal_column('rownum') <= 165) #.yield_per(per_page)
     else:
-        results = results.limit(500)
+        results = results.limit(165)
+
+    # for debugging, print out the exact query.
+    # from sqlalchemy.dialects import oracle
+    # oracle_dialect = oracle.dialect(max_identifier_length=30)
+    # raise Exception(results.statement.compile(dialect=oracle_dialect))
 
     current_app.logger.info('After query')
 
@@ -153,9 +155,9 @@ def corpparty_search_export():
     # Fetching results
     results = CorpParty.search_corp_parties(args)
     if current_app.config.get('IS_ORACLE'):
-        results = results.filter(literal_column('rownum') <= 500).yield_per(50)
+        results = results.filter(literal_column('rownum') <= 165)
     else:
-        results = results.limit(500)
+        results = results.limit(165)
 
     # Exporting to Excel
     workbook = Workbook()

--- a/search-web/src/components/Search/corporation/CorporationTable.vue
+++ b/search-web/src/components/Search/corporation/CorporationTable.vue
@@ -240,7 +240,7 @@ export default {
           this.corporations = result.data.results;
           this.totalItems = result.data.numResults;
           this.$emit("success", result);
-          this.totalItems >= 500 ? this.$emit("overload") : "";
+          this.totalItems >= 165 ? this.$emit("overload") : "";
         })
         .catch(e => {
           this.corporations = [];

--- a/search-web/src/components/Search/corpparty/CorpPartyTable.vue
+++ b/search-web/src/components/Search/corpparty/CorpPartyTable.vue
@@ -387,7 +387,7 @@ export default {
           this.items = result.data.results;
           this.totalItems = result.data.numResults;
           this.$emit("success", result);
-          this.totalItems >= 500 ? this.$emit("overload") : "";
+          this.totalItems >= 165 ? this.$emit("overload") : "";
         })
         .catch(e => {
           this.items = [];

--- a/search-web/src/views/CorpPartySearch.vue
+++ b/search-web/src/views/CorpPartySearch.vue
@@ -244,7 +244,7 @@ export default {
     handleOverload() {
       this.overload = true;
       this.overloadMessage =
-        "Your search returned 500 or more results, which is the limit of the Director Search. Results will be missing at random, irrespective of sorting. Please be sure to narrow your search in order to receive a usable results list.";
+        "Your search returned 165 or more results, which is the limit of the Director Search. Results will be missing at random, irrespective of sorting. Please be sure to narrow your search in order to receive a usable results list.";
     },
     resetError() {
       this.error = false;

--- a/search-web/src/views/CorporationSearch.vue
+++ b/search-web/src/views/CorporationSearch.vue
@@ -134,7 +134,7 @@ export default {
     handleOverload() {
       this.overload = true;
       this.overloadMessage =
-        "Your search returned 500 or more results, which is the limit of the Corporation Search. Results will be missing at random, irrespective of sorting. Please be sure to narrow your search in order to receive a usable results list.";
+        "Your search returned 165 or more results, which is the limit of the Corporation Search. Results will be missing at random, irrespective of sorting. Please be sure to narrow your search in order to receive a usable results list.";
     },
     handleError(error) {
       this.errorMessage = `${error.toString()} ${(error.response &&


### PR DESCRIPTION
Previously a bug in our query was excluding all historical results. Now,
we include them, but due to the performance hit, had to reduce the max
results size to be the same as the old COBRS, at 165.